### PR TITLE
Add Starlight docs integration

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { fileURLToPath } from 'url';
 import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';
+import starlight from '@astrojs/starlight';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 
@@ -22,6 +23,9 @@ export default defineConfig({
   },
   integrations: [
     react(),
+    starlight({
+      title: 'Blue Frog Analytics Docs',
+    }),
     mdx({
       remarkPlugins: [remarkMath],
       rehypePlugins: [rehypeKatex],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,10 +11,11 @@
   "dependencies": {
     "@astrojs/mdx": "^4.3.0",
     "@astrojs/react": "^4.3.0",
+    "@astrojs/starlight": "^0.35.1",
     "@hookform/resolvers": "^3.3.4",
+    "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
     "@radix-ui/react-avatar": "^1.1.10",
-    "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-navigation-menu": "^1.2.13",
     "@radix-ui/react-select": "^2.2.5",
@@ -30,6 +31,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-auto-scroll": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
+    "firebase": "^11.9.1",
     "lucide-react": "^0.513.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -39,8 +41,7 @@
     "remark-math": "^6.0.0",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.3",
-    "zod": "^3.23.8",
-    "firebase": "^11.9.1"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",


### PR DESCRIPTION
## Summary
- install `@astrojs/starlight`
- enable the Starlight integration in Astro config with a basic title

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ca0fb1a908323a45f684dfd56a501