### PR TITLE
Refine home page copy and features

### DIFF
--- a/frontend/src/components/sections/Hero53.tsx
+++ b/frontend/src/components/sections/Hero53.tsx
@@ -9,8 +9,7 @@ const Hero53 = () => {
       <div className="container px-4 sm:px-6 md:px-8">
         <div className="absolute inset-0 -z-10 h-full w-full bg-[radial-gradient(var(--muted-foreground)_1px,transparent_1px)] [background-size:14px_14px] opacity-35"></div>
         <h1 className="text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl xl:text-8xl">
-          Your Website Already Knows What's Broken—Blue Frog Shows You How to
-          Fix It.
+          Your SMB's Secret Key to Growth
         </h1>
         <div className="mt-10 flex flex-col-reverse gap-8 md:mt-12 md:flex-row md:items-center md:gap-10 lg:mt-14">
           <div className="flex flex-col gap-6">
@@ -44,8 +43,8 @@ const Hero53 = () => {
             </div>
           </div>
           <p className="max-w-lg text-xl leading-relaxed text-muted-foreground">
-            Automated audits, instant insights, and actionable growth playbooks.
-            Identify and fix critical website issues within hours.
+            Targeted leads, unified dashboards and hands-on website expertise.
+            Browse our free docs or request a full audit—no CTO required.
           </p>
         </div>
       </div>

--- a/frontend/src/components/sections/HomeFeatures.tsx
+++ b/frontend/src/components/sections/HomeFeatures.tsx
@@ -1,0 +1,52 @@
+import { BookOpen, Briefcase, Code, LayoutDashboard, Search } from "lucide-react";
+
+const features = [
+  {
+    icon: Search,
+    title: "Lead Services",
+    description: "High-intent local leads delivered right to your dashboard."
+  },
+  {
+    icon: LayoutDashboard,
+    title: "Domain Dashboard",
+    description: "Monitor uptime, SEO and performance metrics in one place."
+  },
+  {
+    icon: Code,
+    title: "Website Services",
+    description: "Design, content updates and managed hosting handled by experts."
+  },
+  {
+    icon: BookOpen,
+    title: "Free Documentation",
+    description: "Step-by-step guides to level up your team at no cost."
+  },
+  {
+    icon: Briefcase,
+    title: "Consulting & Audits",
+    description: "Strategic sessions and deep audits—no CTO required."
+  }
+];
+
+const HomeFeatures = () => {
+  return (
+    <section className="py-20">
+      <div className="container">
+        <h2 className="mb-10 text-center text-3xl font-semibold md:text-4xl">
+          What We Do
+        </h2>
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {features.map(({ icon: Icon, title, description }) => (
+            <div key={title} className="flex flex-col items-start gap-3">
+              <Icon className="size-8 text-primary" />
+              <h3 className="text-xl font-medium">{title}</h3>
+              <p className="text-muted-foreground">{description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export { HomeFeatures };

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -2,9 +2,9 @@
 import Layout from '../layouts/main.astro';
 export const title = 'Home';
 import { Hero53 } from "../components/sections/Hero53";
-import { Feature250 } from "../components/sections/Feature250";
+import { HomeFeatures } from "../components/sections/HomeFeatures";
 ---
 <Layout title={title}>
   <Hero53 />
-  <Feature250 client:load />
+  <HomeFeatures />
 </Layout>


### PR DESCRIPTION
## Summary
- tweak hero copy to emphasize SMB benefits
- replace broken feature section with new `HomeFeatures`
- hook the new section into the home page

## Testing
- `pytest -q`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ff9377d7883239dd6c814abd10ed8