### PR TITLE
Focus nav and homepage on Bernays content

### DIFF
--- a/frontend/src/components/layout/Navbar3.tsx
+++ b/frontend/src/components/layout/Navbar3.tsx
@@ -46,40 +46,28 @@ import {
 
 const solutions = [
   {
-    title: "SEO",
-    description: "Optimize search visibility and rankings",
-    href: "/services/seo",
-    icon: Search,
-  },
-  {
-    title: "Performance",
-    description: "Improve speed and Core Web Vitals",
-    href: "/services/performance",
-    icon: Gauge,
-  },
-  {
-    title: "Marketing",
-    description: "Engage visitors with targeted campaigns",
-    href: "/services/marketing",
-    icon: Megaphone,
-  },
-  {
-    title: "Consulting",
-    description: "Get expert guidance on analytics strategy",
-    href: "/services/consulting",
+    title: "Bernays Playbook",
+    description: "Proven persuasion tactics for modern brands",
+    href: "/bernays-playbook",
     icon: Book,
   },
   {
-    title: "Compliance",
-    description: "Stay ahead of privacy regulations",
-    href: "/services/compliance",
-    icon: ShieldCheck,
+    title: "PR Consulting",
+    description: "Strategy sessions to shape public opinion",
+    href: "/services/consulting",
+    icon: Megaphone,
   },
   {
-    title: "Accessibility",
-    description: "Ensure an inclusive experience",
-    href: "/services/accessibility",
-    icon: Accessibility,
+    title: "Campaign Services",
+    description: "Full-service influence campaigns",
+    href: "/services/marketing",
+    icon: Gauge,
+  },
+  {
+    title: "Influence Dashboard",
+    description: "Track sentiment and outreach in one place",
+    href: "/dashboard",
+    icon: BarChart,
   },
 ];
 
@@ -128,6 +116,11 @@ const documentationLinks = [
 ];
 
 const resources = [
+  {
+    title: "Bernays Playbook",
+    description: "Download our guide to modern persuasion",
+    href: "/bernays-playbook",
+  },
   {
     title: "Documentation",
     description: "In sapien tellus, sodales in pharetra a, mattis ac turpis.",

--- a/frontend/src/components/sections/Hero53.tsx
+++ b/frontend/src/components/sections/Hero53.tsx
@@ -9,12 +9,14 @@ const Hero53 = () => {
       <div className="container px-4 sm:px-6 md:px-8">
         <div className="absolute inset-0 -z-10 h-full w-full bg-[radial-gradient(var(--muted-foreground)_1px,transparent_1px)] [background-size:14px_14px] opacity-35"></div>
         <h1 className="text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl xl:text-8xl">
-          Your SMB's Secret Key to Growth
+          Master Public Relations the Bernays Way
         </h1>
         <div className="mt-10 flex flex-col-reverse gap-8 md:mt-12 md:flex-row md:items-center md:gap-10 lg:mt-14">
           <div className="flex flex-col gap-6">
-            <Button className="px-6 py-5 bg-blue-600 hover:bg-blue-700 text-white sm:w-fit">
-              Start Free Scan <Globe className="size-4 ml-2" />
+            <Button asChild className="px-6 py-5 bg-blue-600 hover:bg-blue-700 text-white sm:w-fit">
+              <a href="/bernays-playbook">
+                Get the Bernays Playbook <Globe className="size-4 ml-2" />
+              </a>
             </Button>
             <div className="flex items-center gap-3">
               <span className="inline-flex items-center -space-x-1.5">
@@ -43,8 +45,8 @@ const Hero53 = () => {
             </div>
           </div>
           <p className="max-w-lg text-xl leading-relaxed text-muted-foreground">
-            Targeted leads, unified dashboards and hands-on website expertise.
-            Browse our free docs or request a full audit—no CTO required.
+            Discover how strategic influence can transform your brand. Grab the
+            playbook and start shaping public opinion today.
           </p>
         </div>
       </div>

--- a/frontend/src/components/sections/HomeFeatures.tsx
+++ b/frontend/src/components/sections/HomeFeatures.tsx
@@ -1,31 +1,30 @@
-import { BookOpen, Briefcase, Code, LayoutDashboard, Search } from "lucide-react";
+import { BookOpen, Briefcase, LayoutDashboard, Megaphone } from "lucide-react";
 
 const features = [
   {
-    icon: Search,
-    title: "Lead Services",
-    description: "High-intent local leads delivered right to your dashboard."
-  },
-  {
-    icon: LayoutDashboard,
-    title: "Domain Dashboard",
-    description: "Monitor uptime, SEO and performance metrics in one place."
-  },
-  {
-    icon: Code,
-    title: "Website Services",
-    description: "Design, content updates and managed hosting handled by experts."
-  },
-  {
     icon: BookOpen,
-    title: "Free Documentation",
-    description: "Step-by-step guides to level up your team at no cost."
+    title: "Bernays Playbook",
+    description: "Step-by-step persuasion guide for your team.",
+    href: "/bernays-playbook",
   },
   {
     icon: Briefcase,
-    title: "Consulting & Audits",
-    description: "Strategic sessions and deep audits—no CTO required."
-  }
+    title: "PR Consulting",
+    description: "Hands-on guidance to craft your narrative.",
+    href: "/services/consulting",
+  },
+  {
+    icon: Megaphone,
+    title: "Campaign Services",
+    description: "Influence campaigns executed across media.",
+    href: "/services/marketing",
+  },
+  {
+    icon: LayoutDashboard,
+    title: "Influence Dashboard",
+    description: "Monitor sentiment and outreach in one place.",
+    href: "/dashboard",
+  },
 ];
 
 const HomeFeatures = () => {
@@ -33,15 +32,19 @@ const HomeFeatures = () => {
     <section className="py-20">
       <div className="container">
         <h2 className="mb-10 text-center text-3xl font-semibold md:text-4xl">
-          What We Do
+          Bernays-Inspired Offerings
         </h2>
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {features.map(({ icon: Icon, title, description }) => (
-            <div key={title} className="flex flex-col items-start gap-3">
+          {features.map(({ icon: Icon, title, description, href }) => (
+            <a
+              key={title}
+              href={href}
+              className="flex flex-col items-start gap-3 hover:underline"
+            >
               <Icon className="size-8 text-primary" />
               <h3 className="text-xl font-medium">{title}</h3>
               <p className="text-muted-foreground">{description}</p>
-            </div>
+            </a>
           ))}
         </div>
       </div>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -3,8 +3,17 @@ import Layout from '../layouts/main.astro';
 export const title = 'Home';
 import { Hero53 } from "../components/sections/Hero53";
 import { HomeFeatures } from "../components/sections/HomeFeatures";
+import { Cta10 } from "../components/sections/Cta10";
 ---
 <Layout title={title}>
   <Hero53 />
   <HomeFeatures />
+  <Cta10
+    heading="Ready to Influence?"
+    description="Schedule a consultation and put Bernays' principles into action."
+    buttons={{
+      primary: { text: 'Book Now', url: '/booking' },
+      secondary: { text: 'Learn More', url: '/services/consulting' },
+    }}
+  />
 </Layout>


### PR DESCRIPTION
## Summary
- highlight Bernays offerings in the navigation
- refocus hero content on the Bernays playbook
- update home features with links to Bernays-inspired services
- add call to action section on the homepage

## Testing
- `pytest -q`
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_6880019b03208323b517e8f5b932b441