### PR TITLE
Revise homepage messaging

### DIFF
--- a/frontend/src/components/layout/Navbar3.tsx
+++ b/frontend/src/components/layout/Navbar3.tsx
@@ -27,6 +27,7 @@ import {
   Wrench,
   Utensils,
   Truck,
+  Briefcase,
   Menu,
   X,
 } from "lucide-react";
@@ -46,28 +47,34 @@ import {
 
 const solutions = [
   {
-    title: "Influence Playbook",
-    description: "Proven persuasion tactics for modern brands",
-    href: "/services/consulting",
-    icon: Book,
-  },
-  {
-    title: "PR Consulting",
-    description: "Strategy sessions to shape public opinion",
-    href: "/services/consulting",
+    title: "Lead Services",
+    description: "Targeted outreach to drive new customers",
+    href: "/services/marketing",
     icon: Megaphone,
   },
   {
-    title: "Campaign Services",
-    description: "Full-service influence campaigns",
-    href: "/services/marketing",
+    title: "Domain Dashboard",
+    description: "Monitor domain metrics and performance",
+    href: "/dashboard",
+    icon: BarChart,
+  },
+  {
+    title: "Website Services",
+    description: "Design, hosting and SEO for your site",
+    href: "/services/launch",
     icon: Gauge,
   },
   {
-    title: "Influence Dashboard",
-    description: "Track sentiment and outreach in one place",
-    href: "/dashboard",
-    icon: BarChart,
+    title: "Free Documentation",
+    description: "Guides covering marketing and analytics",
+    href: "/docs",
+    icon: Book,
+  },
+  {
+    title: "Consulting & Audits",
+    description: "Expert reviews to refine your operations",
+    href: "/services/consulting",
+    icon: Briefcase,
   },
 ];
 
@@ -117,8 +124,8 @@ const documentationLinks = [
 
 const resources = [
   {
-    title: "Influence Playbook",
-    description: "Download our guide to modern persuasion",
+    title: "Marketing Playbook",
+    description: "Download our guide to proven outreach tactics",
     href: "/services/consulting",
   },
   {

--- a/frontend/src/components/sections/Hero53.tsx
+++ b/frontend/src/components/sections/Hero53.tsx
@@ -9,13 +9,13 @@ const Hero53 = () => {
       <div className="container px-4 sm:px-6 md:px-8">
         <div className="absolute inset-0 -z-10 h-full w-full bg-[radial-gradient(var(--muted-foreground)_1px,transparent_1px)] [background-size:14px_14px] opacity-35"></div>
         <h1 className="text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl xl:text-8xl">
-          Master Public Relations with Strategic Influence
+          Master Public Relations with Strategic Marketing
         </h1>
         <div className="mt-10 flex flex-col-reverse gap-8 md:mt-12 md:flex-row md:items-center md:gap-10 lg:mt-14">
           <div className="flex flex-col gap-6">
             <Button asChild className="px-6 py-5 bg-blue-600 hover:bg-blue-700 text-white sm:w-fit">
               <a href="/services/consulting">
-                Get the Influence Playbook <Globe className="size-4 ml-2" />
+                Get the Marketing Playbook <Globe className="size-4 ml-2" />
               </a>
             </Button>
             <div className="flex items-center gap-3">
@@ -45,8 +45,8 @@ const Hero53 = () => {
             </div>
           </div>
           <p className="max-w-lg text-xl leading-relaxed text-muted-foreground">
-            Discover how strategic influence can transform your brand. Grab the
-            playbook and start shaping public opinion today.
+            Discover how strategic marketing can transform your brand. Grab the
+            playbook and start shaping public perception today.
           </p>
         </div>
       </div>

--- a/frontend/src/components/sections/HomeFeatures.tsx
+++ b/frontend/src/components/sections/HomeFeatures.tsx
@@ -1,29 +1,35 @@
-import { BookOpen, Briefcase, LayoutDashboard, Megaphone } from "lucide-react";
+import { BookOpen, Briefcase, LayoutDashboard, Megaphone, Globe } from "lucide-react";
 
 const features = [
   {
-    icon: BookOpen,
-    title: "Influence Playbook",
-    description: "Step-by-step persuasion guide for your team.",
-    href: "/services/consulting",
-  },
-  {
-    icon: Briefcase,
-    title: "PR Consulting",
-    description: "Hands-on guidance to craft your narrative.",
-    href: "/services/consulting",
-  },
-  {
     icon: Megaphone,
-    title: "Campaign Services",
-    description: "Influence campaigns executed across media.",
+    title: "Lead Services",
+    description: "Capture and convert prospects with targeted outreach.",
     href: "/services/marketing",
   },
   {
     icon: LayoutDashboard,
-    title: "Influence Dashboard",
-    description: "Monitor sentiment and outreach in one place.",
+    title: "Domain Dashboard",
+    description: "Monitor domain metrics and online health in real time.",
     href: "/dashboard",
+  },
+  {
+    icon: Globe,
+    title: "Website Services",
+    description: "Design, hosting and SEO for your site.",
+    href: "/services/launch",
+  },
+  {
+    icon: BookOpen,
+    title: "Free Documentation",
+    description: "Guides and best practices for marketing and analytics.",
+    href: "/docs",
+  },
+  {
+    icon: Briefcase,
+    title: "Consulting & Audits",
+    description: "Detailed analysis and expert guidance.",
+    href: "/services/consulting",
   },
 ];
 
@@ -32,9 +38,9 @@ const HomeFeatures = () => {
     <section className="py-20">
       <div className="container">
         <h2 className="mb-10 text-center text-3xl font-semibold md:text-4xl">
-          Influence-Focused Offerings
+          Our Core Offerings
         </h2>
-        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-8 md:grid-cols-3 lg:grid-cols-5">
           {features.map(({ icon: Icon, title, description, href }) => (
             <a
               key={title}

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -9,8 +9,8 @@ import { Cta10 } from "../components/sections/Cta10";
   <Hero53 />
   <HomeFeatures />
   <Cta10
-    heading="Ready to Influence?"
-    description="Schedule a consultation and put proven principles into action."
+    heading="Ready to Grow?"
+    description="Schedule a consultation and put proven marketing principles into action."
     buttons={{
       primary: { text: 'Book Now', url: '/booking' },
       secondary: { text: 'Learn More', url: '/services/consulting' },


### PR DESCRIPTION
## Summary
- reword hero section to use marketing language
- expand home page features for marketing services, dashboard, docs and audits
- update CTA copy
- update navbar to highlight key offerings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688062a0708083239a5838ab735a2957