### PR TITLE
Expand marketing automation page

### DIFF
--- a/frontend/src/pages/services/marketing.astro
+++ b/frontend/src/pages/services/marketing.astro
@@ -7,6 +7,32 @@ export const title = 'Marketing Automation';
   <section class="container py-8">
     <h1 class="mb-4 text-4xl font-semibold">Marketing Automation</h1>
     <p class="mb-6 text-muted-foreground">Engage customers with targeted campaigns.</p>
+    <div class="max-w-3xl space-y-4">
+      <p>
+        Blue Frog Analytics monitors almost every reachable domain and
+        automatically determines which ones belong to real businesses. We look
+        for service pages, e-commerce sections and other signals to filter out
+        personal sites and placeholders.
+      </p>
+      <p>
+        Qualified domains are enriched with phone numbers, email addresses and
+        technology details. Map listings help us tie many of these sites to
+        physical locations, and coverage grows daily.
+      </p>
+      <p>
+        Every domain also receives a Lighthouse audit, letting you pinpoint
+        businesses with poor SEO, slow performance or missing analytics. These
+        leads are cold but deeply researched and updated on a regular basis.
+      </p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>Comprehensive domain monitoring</li>
+        <li>Business detection via service and product signals</li>
+        <li>Phone and email contact details</li>
+        <li>Expanding address coverage</li>
+        <li>Lighthouse SEO and performance scores</li>
+        <li>Filterable lead lists for targeted outreach</li>
+      </ul>
+    </div>
   </section>
   <Feature22 />
 </Layout>


### PR DESCRIPTION
## Summary
- add details on monitoring domains and enrichment
- highlight lighthouse scores and lead list features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806952f0dc8323bf4d164a275651ac