### PR TITLE
Update docs with page list reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,11 @@ This guide explains how to set up an **Astro** project with **Tailwind CSS** and
 
 By the end, you'll have a reference for building an Astro project that leverages Tailwind's utilities, shadcn's component library, and pre-designed blocks from shadcn Blocks Pro to quickly assemble robust UIs.
 
+For a catalog of every page in the site check `PAGE_STRUCTURE.md` (also
+mirrored as `SITE_PAGES_OVERVIEW.md`) in the repository root. Update this
+listing whenever pages are added or removed from `frontend/src/pages` so it stays
+accurate.
+
 1\. Project Setup: Astro with Tailwind CSS and React
 ----------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ npm run build
 
 Static documentation content resides in `src/content/docs`.
 
+The full list of site pages is maintained in `SITE_PAGES_OVERVIEW.md`
+(duplicated as `PAGE_STRUCTURE.md`). Keep this file updated whenever new pages
+are added under `frontend/src/pages`.
+
 ## API server
 
 The API server under `server/apiServer.js` exposes endpoints for profile management and website audits. It requires a Firebase service account and Cassandra connection details. If `FIREBASE_SERVICE_ACCOUNT` is not set, the server falls back to `server/serviceAccount.json`.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -16,5 +16,6 @@ This document summarizes the new frontend located in `frontend/`. The site is bu
 - Client Login & Dashboard under `/dashboard` with various sub-pages
 - Extensive documentation under `/docs`
 - Blog (`/blog`) with posts sourced from `src/content/blog`
+See `SITE_PAGES_OVERVIEW.md` at the project root for a complete list of site pages. Keep that document in sync whenever files in `src/pages` change.
 
 The Express API lives in `server/` and bots in `bots/` remain unchanged from the original site.


### PR DESCRIPTION
## Summary
- mention site page listing in README
- point AGENTS files to PAGE_STRUCTURE

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806c5671ec8323a8301621e5d480c8