### PR TITLE
Improve launch page with styled pricing

### DIFF
--- a/frontend/src/components/sections/LaunchPricing.tsx
+++ b/frontend/src/components/sections/LaunchPricing.tsx
@@ -1,0 +1,61 @@
+import { Check } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+
+const features = [
+  "Modern and optimized brochure website",
+  "SEO & analytics included",
+  "NAP and menu monitoring for accuracy",
+  "Reliable monthly refinements",
+]
+
+const LaunchPricing = () => {
+  return (
+    <section className="py-16">
+      <div className="container">
+        <div className="mx-auto max-w-4xl rounded-lg border p-6 md:p-10">
+          <h2 className="mb-2 text-center text-3xl font-semibold">Business Launch Kit</h2>
+          <p className="mb-6 text-center text-muted-foreground">
+            We handle the technical work so you can focus on success.
+          </p>
+          <ul className="mb-8 grid gap-3 sm:grid-cols-2">
+            {features.map((item) => (
+              <li key={item} className="flex items-start gap-2">
+                <Check className="mt-0.5 size-4 text-primary" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+          <Separator className="mb-8" />
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="flex flex-col items-center rounded-md border bg-muted/50 p-6 text-center">
+              <h3 className="mb-2 text-xl font-semibold">Complete Package</h3>
+              <p className="mb-4 text-muted-foreground">
+                Unlimited updates, free domain and lead dashboard access.
+              </p>
+              <p className="mb-6 text-4xl font-bold">
+                $100<span className="text-lg font-medium">/month</span>
+              </p>
+              <Button size="lg">Get Started</Button>
+            </div>
+            <div className="flex flex-col items-center rounded-md border p-6 text-center">
+              <h3 className="mb-2 text-xl font-semibold">Budget Option</h3>
+              <p className="mb-4 text-muted-foreground">
+                Keeps hosting and analytics running with limited updates.
+              </p>
+              <p className="mb-6 text-4xl font-bold">
+                $25<span className="text-lg font-medium">/month</span>
+              </p>
+              <Button variant="outline" size="lg">
+                Choose Plan
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export { LaunchPricing }

--- a/frontend/src/pages/services/launch.astro
+++ b/frontend/src/pages/services/launch.astro
@@ -5,6 +5,7 @@ import { LaunchFeatures } from '../../components/sections/LaunchFeatures';
 import { Logos10 } from '../../components/sections/Logos10';
 import { TestimonialCards } from '../../components/sections/TestimonialCards';
 import { Cta10 } from '../../components/sections/Cta10';
+import { LaunchPricing } from '../../components/sections/LaunchPricing';
 export const title = 'Business Launch Kit';
 ---
 <Layout title={title}>
@@ -25,18 +26,7 @@ export const title = 'Business Launch Kit';
       ],
     }}
   />
-  <section class="container py-16">
-    <h2 class="mb-4 text-3xl font-semibold">Business Launch Kit</h2>
-    <p class="mb-4">We handle the technical work so you can focus on success.</p>
-    <ul class="mb-6 list-disc space-y-1 pl-6">
-      <li>Modern and optimized brochure website</li>
-      <li>SEO & Analytics included</li>
-      <li>NAP and menu monitoring for accuracy</li>
-      <li>Reliable monthly refinements</li>
-    </ul>
-    <p class="mb-2 font-medium">$100/month – Full website package with unlimited updates, free domain and lead dashboard access.</p>
-    <p class="mb-6 font-medium">$25/month – Budget option that keeps hosting and analytics running. Dashboard access not included and updates are limited.</p>
-  </section>
+  <LaunchPricing />
   <LaunchFeatures />
   <Logos10 />
   <TestimonialCards />

--- a/frontend/src/pages/testing.mdx
+++ b/frontend/src/pages/testing.mdx
@@ -2,16 +2,15 @@
 layout: '../layouts/main.astro'
 title: Free Analytics Audit Tools
 description: Validate your tracking setup and see exactly what's costing you money - completely free.
-
+---
 import { Hero3 } from '../components/sections/Hero3';
 
-const modules = import.meta.glob('./tests/*.mdx', { eager: true });
-const tests = Object.entries(modules).map(([path, mod]) => ({
+export const modules = import.meta.glob('./tests/*.mdx', { eager: true });
+export const tests = Object.entries(modules).map(([path, mod]) => ({
   slug: path.replace('./tests/', '/tests/').replace(/\.mdx$/, ''),
   title: mod.frontmatter.title,
   description: mod.frontmatter.description
 })).sort((a, b) => a.title.localeCompare(b.title));
----
 
 <Hero3
   heading="Discover What's Bleeding Your Revenue"


### PR DESCRIPTION
## Summary
- add LaunchPricing block showing package details
- swap raw markup for new block on launch page
- fix invalid frontmatter in testing.mdx for build

## Testing
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806faa68908323b73f4cf6ce2a3472